### PR TITLE
Android security 11.0.0 release 61

### DIFF
--- a/halimpl/hal/phNxpNciHal_ext.cc
+++ b/halimpl/hal/phNxpNciHal_ext.cc
@@ -765,7 +765,8 @@ NFCSTATUS phNxpNciHal_write_ext(uint16_t* cmd_len, uint8_t* p_cmd_data,
     status = NFCSTATUS_FAILED;
   }
   // 2002 0904 3000 3100 3200 5000
-  else if ((p_cmd_data[0] == 0x20 && p_cmd_data[1] == 0x02) &&
+  else if (*cmd_len <= (NCI_MAX_DATA_LEN - 1) &&
+           (p_cmd_data[0] == 0x20 && p_cmd_data[1] == 0x02) &&
            ((p_cmd_data[2] == 0x09 && p_cmd_data[3] == 0x04) /*||
             (p_cmd_data[2] == 0x0D && p_cmd_data[3] == 0x04)*/
             )) {


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r61' of https://android.googlesource.com/platform/hardware/nxp/nfc into arrow-11.0

Android security 11.0.0 release 61
Tag: https://android.googlesource.com/platform/hardware/nxp/nfc/+/refs/tags/android-security-11.0.0_r61

Merge cherrypicks of [19518245] into security-aosp-rvc-release.

Change-Id: [Id0e599c23ddcfc021cb7b97d54ecd400086b4f1b](https://android-review.googlesource.com/#/q/Id0e599c23ddcfc021cb7b97d54ecd400086b4f1b)