### PR TITLE
Android security 11.0.0 release 62

### DIFF
--- a/halimpl/mifare/NxpMfcReader.cc
+++ b/halimpl/mifare/NxpMfcReader.cc
@@ -60,7 +60,7 @@ int NxpMfcReader::Write(uint16_t mfcDataLen, const uint8_t *pMfcData) {
   /* send TAG_CMD part 2 for Mifare increment ,decrement and restore commands */
   if (mfcTagCmdBuff[4] == eMifareDec || mfcTagCmdBuff[4] == eMifareInc ||
       mfcTagCmdBuff[4] == eMifareRestore) {
-    SendIncDecRestoreCmdPart2(pMfcData);
+    SendIncDecRestoreCmdPart2(mfcDataLen, pMfcData);
   }
   return writtenDataLen;
 }
@@ -264,14 +264,20 @@ void NxpMfcReader::AuthForWrite() {
 ** Returns          None
 **
 *******************************************************************************/
-void NxpMfcReader::SendIncDecRestoreCmdPart2(const uint8_t *mfcData) {
+void NxpMfcReader::SendIncDecRestoreCmdPart2(uint16_t mfcDataLen,
+                                             const uint8_t *mfcData) {
   NFCSTATUS status = NFCSTATUS_SUCCESS;
   /* Build TAG_CMD part 2 for Mifare increment ,decrement and restore commands*/
   uint8_t incDecRestorePart2[] = {0x00, 0x00, 0x05, (uint8_t)eMfRawDataXchgHdr,
                                   0x00, 0x00, 0x00, 0x00};
   uint8_t incDecRestorePart2Size =
       (sizeof(incDecRestorePart2) / sizeof(incDecRestorePart2[0]));
+
   if (mfcData[3] == eMifareInc || mfcData[3] == eMifareDec) {
+    if (incDecRestorePart2Size >= mfcDataLen) {
+      incDecRestorePart2Size = mfcDataLen - 1;
+      android_errorWriteLog(0x534e4554, "238177877");
+    }
     for (int i = 4; i < incDecRestorePart2Size; i++) {
       incDecRestorePart2[i] = mfcData[i + 1];
     }

--- a/halimpl/mifare/NxpMfcReader.h
+++ b/halimpl/mifare/NxpMfcReader.h
@@ -109,7 +109,7 @@ private:
   void BuildIncDecCmd();
   void CalcSectorAddress();
   void AuthForWrite();
-  void SendIncDecRestoreCmdPart2(const uint8_t *mfcData);
+  void SendIncDecRestoreCmdPart2(uint16_t mfcDataLen, const uint8_t* mfcData);
 
 public:
   int Write(uint16_t mfcDataLen, const uint8_t *pMfcData);


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r62' of https://android.googlesource.com/platform/hardware/nxp/nfc into arrow-11.0

Android security 11.0.0 release 62
Tag: https://android.googlesource.com/platform/hardware/nxp/nfc/+/refs/tags/android-security-11.0.0_r62

Merge cherrypicks of [19998445] into security-aosp-rvc-release.

Change-Id: [I10b436d129acdc921d63402b225423b68df81fed](https://android-review.googlesource.com/#/q/I10b436d129acdc921d63402b225423b68df81fed)