### PR TITLE
Android security 11.0.0 release 66

### DIFF
--- a/halimpl/mifare/NxpMfcReader.cc
+++ b/halimpl/mifare/NxpMfcReader.cc
@@ -54,13 +54,13 @@ int NxpMfcReader::Write(uint16_t mfcDataLen, const uint8_t *pMfcData) {
   BuildMfcCmd(&mfcTagCmdBuff[3], &mfcTagCmdBuffLen);
 
   mfcTagCmdBuff[2] = mfcTagCmdBuffLen;
-  mfcDataLen = mfcTagCmdBuffLen + NCI_HEADER_SIZE;
-  int writtenDataLen = phNxpNciHal_write_internal(mfcDataLen, mfcTagCmdBuff);
+  int writtenDataLen = phNxpNciHal_write_internal(
+      mfcTagCmdBuffLen + NCI_HEADER_SIZE, mfcTagCmdBuff);
 
   /* send TAG_CMD part 2 for Mifare increment ,decrement and restore commands */
   if (mfcTagCmdBuff[4] == eMifareDec || mfcTagCmdBuff[4] == eMifareInc ||
       mfcTagCmdBuff[4] == eMifareRestore) {
-    SendIncDecRestoreCmdPart2(pMfcData);
+    SendIncDecRestoreCmdPart2(mfcDataLen, pMfcData);
   }
   return writtenDataLen;
 }
@@ -264,7 +264,8 @@ void NxpMfcReader::AuthForWrite() {
 ** Returns          None
 **
 *******************************************************************************/
-void NxpMfcReader::SendIncDecRestoreCmdPart2(const uint8_t *mfcData) {
+void NxpMfcReader::SendIncDecRestoreCmdPart2(uint16_t mfcDataLen,
+                                             const uint8_t *mfcData) {
   NFCSTATUS status = NFCSTATUS_SUCCESS;
   /* Build TAG_CMD part 2 for Mifare increment ,decrement and restore commands*/
   uint8_t incDecRestorePart2[] = {0x00, 0x00, 0x05, (uint8_t)eMfRawDataXchgHdr,
@@ -272,6 +273,10 @@ void NxpMfcReader::SendIncDecRestoreCmdPart2(const uint8_t *mfcData) {
   uint8_t incDecRestorePart2Size =
       (sizeof(incDecRestorePart2) / sizeof(incDecRestorePart2[0]));
   if (mfcData[3] == eMifareInc || mfcData[3] == eMifareDec) {
+    if (incDecRestorePart2Size >= mfcDataLen) {
+      incDecRestorePart2Size = mfcDataLen - 1;
+      android_errorWriteLog(0x534e4554, "238177877");
+    }
     for (int i = 4; i < incDecRestorePart2Size; i++) {
       incDecRestorePart2[i] = mfcData[i + 1];
     }

--- a/halimpl/mifare/NxpMfcReader.cc
+++ b/halimpl/mifare/NxpMfcReader.cc
@@ -60,7 +60,7 @@ int NxpMfcReader::Write(uint16_t mfcDataLen, const uint8_t *pMfcData) {
   /* send TAG_CMD part 2 for Mifare increment ,decrement and restore commands */
   if (mfcTagCmdBuff[4] == eMifareDec || mfcTagCmdBuff[4] == eMifareInc ||
       mfcTagCmdBuff[4] == eMifareRestore) {
-    SendIncDecRestoreCmdPart2(mfcDataLen, pMfcData);
+    SendIncDecRestoreCmdPart2(pMfcData);
   }
   return writtenDataLen;
 }
@@ -264,20 +264,14 @@ void NxpMfcReader::AuthForWrite() {
 ** Returns          None
 **
 *******************************************************************************/
-void NxpMfcReader::SendIncDecRestoreCmdPart2(uint16_t mfcDataLen,
-                                             const uint8_t *mfcData) {
+void NxpMfcReader::SendIncDecRestoreCmdPart2(const uint8_t *mfcData) {
   NFCSTATUS status = NFCSTATUS_SUCCESS;
   /* Build TAG_CMD part 2 for Mifare increment ,decrement and restore commands*/
   uint8_t incDecRestorePart2[] = {0x00, 0x00, 0x05, (uint8_t)eMfRawDataXchgHdr,
                                   0x00, 0x00, 0x00, 0x00};
   uint8_t incDecRestorePart2Size =
       (sizeof(incDecRestorePart2) / sizeof(incDecRestorePart2[0]));
-
   if (mfcData[3] == eMifareInc || mfcData[3] == eMifareDec) {
-    if (incDecRestorePart2Size >= mfcDataLen) {
-      incDecRestorePart2Size = mfcDataLen - 1;
-      android_errorWriteLog(0x534e4554, "238177877");
-    }
     for (int i = 4; i < incDecRestorePart2Size; i++) {
       incDecRestorePart2[i] = mfcData[i + 1];
     }

--- a/halimpl/mifare/NxpMfcReader.h
+++ b/halimpl/mifare/NxpMfcReader.h
@@ -109,7 +109,7 @@ private:
   void BuildIncDecCmd();
   void CalcSectorAddress();
   void AuthForWrite();
-  void SendIncDecRestoreCmdPart2(const uint8_t *mfcData);
+  void SendIncDecRestoreCmdPart2(uint16_t mfcDataLen, const uint8_t *mfcData);
 
 public:
   int Write(uint16_t mfcDataLen, const uint8_t *pMfcData);

--- a/halimpl/mifare/NxpMfcReader.h
+++ b/halimpl/mifare/NxpMfcReader.h
@@ -109,7 +109,7 @@ private:
   void BuildIncDecCmd();
   void CalcSectorAddress();
   void AuthForWrite();
-  void SendIncDecRestoreCmdPart2(uint16_t mfcDataLen, const uint8_t* mfcData);
+  void SendIncDecRestoreCmdPart2(const uint8_t *mfcData);
 
 public:
   int Write(uint16_t mfcDataLen, const uint8_t *pMfcData);


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r66' of https://android.googlesource.com/platform/hardware/nxp/nfc into arrow-11.0

Android security 11.0.0 release 66
Tag: https://android.googlesource.com/platform/hardware/nxp/nfc/+/refs/tags/android-security-11.0.0_r66

Merge cherrypicks of ['googleplex-android-review.googlesource.com/19998445', 'googleplex-android-review.googlesource.com/21087454', 'googleplex-android-review.googlesource.com/21165987'] into security-aosp-rvc-release.

Change-Id: [If67c50642655d0dfd7564f9a66a1255324986817](https://android-review.googlesource.com/#/q/If67c50642655d0dfd7564f9a66a1255324986817)