### PR TITLE
Android security 11.0.0 release 67

### DIFF
--- a/halimpl/mifare/NxpMfcReader.cc
+++ b/halimpl/mifare/NxpMfcReader.cc
@@ -350,6 +350,10 @@ NFCSTATUS NxpMfcReader::AnalyzeMfcResp(uint8_t *pBuff, uint16_t *pBufflen) {
     } break;
 
     case eMfcAuthRsp: {
+      if (*pBufflen < 2) {
+        status = NFCSTATUS_FAILED;
+        break;
+      }
       /* check the status byte */
       if (NFCSTATUS_SUCCESS == pBuff[1]) {
         status = NFCSTATUS_SUCCESS;


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r67' of https://android.googlesource.com/platform/hardware/nxp/nfc into arrow-11.0

Android security 11.0.0 release 67
Tag: https://android.googlesource.com/platform/hardware/nxp/nfc/+/refs/tags/android-security-11.0.0_r67

Merge cherrypicks of ['googleplex-android-review.googlesource.com/21683219'] into security-aosp-rvc-release.

Change-Id: [Ie70bf6ff9d0957b9a5893bb634a04881898bc5ca](https://android-review.googlesource.com/#/q/Ie70bf6ff9d0957b9a5893bb634a04881898bc5ca)